### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ export default {
   },
 
   isPartsObject(obj = {}) {
+    if (typeof obj !== 'object') return false;
     const inputsKeys = Object.keys(obj);
     const requiredKeys = Object.keys(partConstants);
     const filteredKeys = requiredKeys.filter(k => inputsKeys.includes(k));


### PR DESCRIPTION
Object.keys(obj) will fail in IE with "Object.keys: argument is not an Object" if "obj" is a string